### PR TITLE
fix(deps): bump flatted to 3.4.2 (GHSA-rf6f-7fwh-wjgh)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,14 +56,17 @@
     "lorikeetai-node-sdk": "bin/cli"
   },
   "overrides": {
+    "flatted": "^3.4.2",
     "minimatch": "^9.0.5"
   },
   "pnpm": {
     "overrides": {
+      "flatted": "^3.4.2",
       "minimatch": "^9.0.5"
     }
   },
   "resolutions": {
+    "flatted": "^3.4.2",
     "minimatch": "^9.0.5"
   },
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1769,10 +1769,10 @@ flat-cache@^4.0.0:
     flatted "^3.2.9"
     keyv "^4.5.4"
 
-flatted@^3.2.9:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
-  integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
+flatted@^3.2.9, flatted@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

Bumps `flatted` to **3.4.2** to fix GHSA-rf6f-7fwh-wjgh (CVE-2026-33228, High): prototype pollution via `flatted` `parse()`. The lockfile was resolving `flatted` to 3.3.2 (a dev-scope transitive via `flat-cache` → eslint), within the vulnerable `<= 3.4.1` range.

## Changes

- Adds a bounded `flatted: ^3.4.2` pin to `resolutions`, `overrides`, and `pnpm.overrides` (matching the existing `minimatch` pin).
- Regenerated `yarn.lock`; `flatted` now resolves to a single **3.4.2**, no vulnerable copies remain.

## Verification

- `yarn build` passes: tsc-multi reports 0 errors ([mjs] and [js]), and the CJS `require` + ESM `import` smoke checks succeed.
- flatted is dev-tooling only (eslint cache), so no SDK runtime surface is affected.

Fixes Dependabot alert #32. Closes SEC-565.