### PR TITLE
fix(chat): send auth headers on streamUpdates() SSE connection

### DIFF
--- a/src/resources/conversation/chat.ts
+++ b/src/resources/conversation/chat.ts
@@ -6,6 +6,7 @@ import { APIPromise } from '../../core/api-promise';
 import { RequestOptions } from '../../internal/request-options';
 import { pollUntil } from '../../lib/poll-until';
 import { DeferredAsyncIterable } from '../../lib/promise';
+import { generateSignature } from '../../lib/generate-signature';
 import { EventSource } from 'eventsource';
 
 /**
@@ -119,7 +120,18 @@ export class Chat extends APIResource {
     queries.set('sseMessageTypes', 'new-message,message-chunk,message-complete');
     queries.set('ticketMessageTypes', 'BOT_RESPONSE');
     const url = `${this._client.baseURL}/v1/ticket/sse/${params.conversationId}?${queries.toString()}`;
-    const eventSource = new EventSource(url);
+    const signature = generateSignature(undefined, this._client.clientSecret);
+    const eventSource = new EventSource(url, {
+      fetch: (input, init) =>
+        fetch(input, {
+          ...init,
+          headers: {
+            ...init.headers,
+            Authorization: `Bearer ${this._client.clientID}`,
+            'x-lorikeet-signature': signature,
+          },
+        }),
+    });
     const output = new DeferredAsyncIterable<ChatStreamEvent>();
 
     eventSource.addEventListener('error', (evt) => {

--- a/tests/lib/stream-updates-auth.test.ts
+++ b/tests/lib/stream-updates-auth.test.ts
@@ -1,0 +1,37 @@
+import Lorikeet from '@lorikeetai/node-sdk';
+import { generateSignature } from '@lorikeetai/node-sdk/lib/generate-signature';
+import { EventSource } from 'eventsource';
+
+jest.mock('eventsource', () => ({
+  EventSource: jest.fn().mockImplementation(() => ({ addEventListener: jest.fn() })),
+}));
+
+const clientID = 'My Client ID';
+const clientSecret = 'My Client Secret';
+
+describe('conversation.chat.streamUpdates auth', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test('opens the SSE stream with client_id + empty-body HMAC signature headers', async () => {
+    const client = new Lorikeet({ clientID, clientSecret, baseURL: 'https://api.example.com' });
+
+    client.conversation.chat.streamUpdates({ conversationId: 'abc123' });
+
+    expect(EventSource).toHaveBeenCalledTimes(1);
+    const [url, options] = (EventSource as unknown as jest.Mock).mock.calls[0]!;
+    expect(url).toContain('/v1/ticket/sse/abc123');
+    expect(typeof options.fetch).toBe('function');
+
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null));
+    await options.fetch('https://api.example.com/v1/ticket/sse/abc123', {
+      headers: { Accept: 'text/event-stream' },
+    });
+
+    const passedInit = fetchSpy.mock.calls[0]![1]!;
+    const headers = passedInit.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe(`Bearer ${clientID}`);
+    expect(headers['x-lorikeet-signature']).toBe(generateSignature(undefined, clientSecret));
+    expect(headers['Accept']).toBe('text/event-stream'); // eventsource's own headers preserved
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## What & why

`client.conversation.chat.streamUpdates()` opened the SSE stream with a bare `new EventSource(url)` — no auth headers. The target endpoint `GET /v1/ticket/sse/:ticketId` is auth-guarded and rejects unsigned requests with `400 "Missing signature in header"`, so the method never worked against production auth. (Konfío has been carrying a hand-rolled workaround; any future streaming consumer hits the same 400.)

## The fix

In `src/resources/conversation/chat.ts`, compute the empty-body HMAC signature once and pass a custom `fetch` to the `EventSource` constructor that injects:

- `Authorization: Bearer {clientID}`
- `x-lorikeet-signature` — `generateSignature(undefined, clientSecret)`, the same empty-body HMAC the server recomputes for a bodyless GET

`...init.headers` is spread first so eventsource's own headers (e.g. `Accept: text/event-stream`) are preserved. This reproduces exactly the headers the server has always required, matching Konfío's reference workaround. Scope is one method — `generate`/`get`/`start`/`message`/`poll` and the shared `generate-signature` helper are untouched; no server change.

## Testing

New regression test `tests/lib/stream-updates-auth.test.ts` factory-mocks the `eventsource` module (no network) and asserts the SSE `fetch` carries both auth headers with the correct values and that eventsource's own `Accept` header survives. Verified it fails against the pre-fix code (bare `EventSource(url)` → `options` undefined) and passes with the fix.

Local checks (all green): `yarn jest tests/lib/stream-updates-auth.test.ts`, `yarn build`, `yarn lint`, and the full `yarn test` against the prism mock server (16 suites / 249 tests, including the untouched generated `chat.test.ts`).

## Rollout

No feature flag — this is a client library. Rollout is version-gated by the npm release: the fix rides the next release-please release and consumers opt in by upgrading `@lorikeetai/node-sdk`. Rollback is a revert + patch release; blast radius is nil beyond re-introducing the original bug (there are no working production users of the broken method to regress).

Refs REL-1211