### PR TITLE
feat(conversation): add update() for out-of-band CSAT and conversation fields

### DIFF
--- a/api.md
+++ b/api.md
@@ -5,6 +5,11 @@ Types:
 - <code><a href="./src/resources/conversation/conversation.ts">AttachmentDto</a></code>
 - <code><a href="./src/resources/conversation/conversation.ts">TicketEvent</a></code>
 - <code><a href="./src/resources/conversation/conversation.ts">TicketMessageDto</a></code>
+- <code><a href="./src/resources/conversation/conversation.ts">ConversationUpdateResponse</a></code>
+
+Methods:
+
+- <code title="patch /v1/conversation/{conversationId}">client.conversation.<a href="./src/resources/conversation/conversation.ts">update</a>(conversationID, { ...params }) -> ConversationUpdateResponse</code>
 
 ## Email
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,6 +29,8 @@ import { Ingest, IngestSubmitParams, IngestTestParams } from './resources/ingest
 import {
   AttachmentDto,
   Conversation,
+  ConversationUpdateParams,
+  ConversationUpdateResponse,
   TicketEvent,
   TicketMessageDto,
 } from './resources/conversation/conversation';
@@ -812,6 +814,8 @@ export declare namespace Lorikeet {
     type AttachmentDto as AttachmentDto,
     type TicketEvent as TicketEvent,
     type TicketMessageDto as TicketMessageDto,
+    type ConversationUpdateParams as ConversationUpdateParams,
+    type ConversationUpdateResponse as ConversationUpdateResponse,
   };
 
   export {

--- a/src/resources/conversation/conversation.ts
+++ b/src/resources/conversation/conversation.ts
@@ -1,6 +1,9 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { APIResource } from '../../core/resource';
+import { APIPromise } from '../../core/api-promise';
+import { RequestOptions } from '../../internal/request-options';
+import { path } from '../../internal/utils/path';
 import * as ChatAPI from './chat';
 import {
   Chat,
@@ -28,6 +31,87 @@ export class Conversation extends APIResource {
   email: EmailAPI.Email = new EmailAPI.Email(this._client);
   chat: ChatAPI.Chat = new ChatAPI.Chat(this._client);
   voice: VoiceAPI.Voice = new VoiceAPI.Voice(this._client);
+
+  /**
+   * Update fields on a conversation, such as a CSAT score collected in your own UI.
+   * Requires server-to-server API credentials.
+   *
+   * @example
+   * ```ts
+   * const conversation = await client.conversation.update(
+   *   'conversationId',
+   *   { csatScore: 5 },
+   * );
+   * ```
+   */
+  update(
+    conversationID: string,
+    body: ConversationUpdateParams,
+    options?: RequestOptions,
+  ): APIPromise<ConversationUpdateResponse> {
+    return this._client.patch(path`/v1/conversation/${conversationID}`, { body, ...options });
+  }
+}
+
+export interface ConversationUpdateParams {
+  /**
+   * Customer satisfaction score for the conversation, from 1 (very dissatisfied) to
+   * 5 (very satisfied). Use this to record a CSAT response collected in your own UI.
+   */
+  csatScore?: number;
+
+  /**
+   * When the CSAT response was collected (ISO 8601 format). Defaults to the time of
+   * the request. Requires csatScore.
+   */
+  csatCollectedAt?: string;
+
+  /**
+   * The customer's answer to a "did that help?" style prompt.
+   */
+  csatDidThatHelp?: boolean;
+
+  /**
+   * The title of the conversation.
+   */
+  title?: string;
+}
+
+export interface ConversationUpdateResponse {
+  /**
+   * The ID of the conversation
+   */
+  conversationId: string;
+
+  /**
+   * Customer satisfaction score for the conversation
+   */
+  csatScore: number | null;
+
+  /**
+   * When the CSAT response was collected (ISO 8601 format)
+   */
+  csatCollectedAt: string | null;
+
+  /**
+   * How the CSAT was collected
+   */
+  csatCollectionMethod: 'workflow' | 'widget_inactivity' | 'widget_close' | 'api' | null;
+
+  /**
+   * The customer's answer to a "did that help?" style prompt
+   */
+  csatDidThatHelp: boolean | null;
+
+  /**
+   * The title of the conversation
+   */
+  title: string | null;
+
+  /**
+   * The timestamp of when the conversation was last updated in our system.
+   */
+  updatedAt: string;
 }
 
 export interface AttachmentDto {
@@ -118,6 +202,8 @@ export declare namespace Conversation {
     type AttachmentDto as AttachmentDto,
     type TicketEvent as TicketEvent,
     type TicketMessageDto as TicketMessageDto,
+    type ConversationUpdateParams as ConversationUpdateParams,
+    type ConversationUpdateResponse as ConversationUpdateResponse,
   };
 
   export {

--- a/src/resources/conversation/index.ts
+++ b/src/resources/conversation/index.ts
@@ -14,7 +14,14 @@ export {
   type ChatStreamMessageChunkEvent,
   type ChatStreamMessageCompleteEvent,
 } from './chat';
-export { Conversation, type AttachmentDto, type TicketEvent, type TicketMessageDto } from './conversation';
+export {
+  Conversation,
+  type AttachmentDto,
+  type TicketEvent,
+  type TicketMessageDto,
+  type ConversationUpdateParams,
+  type ConversationUpdateResponse,
+} from './conversation';
 export {
   Email,
   type EmailGenerateResponse,

--- a/tests/lib/conversation-update.test.ts
+++ b/tests/lib/conversation-update.test.ts
@@ -1,0 +1,74 @@
+import Lorikeet from '@lorikeetai/node-sdk';
+
+const clientID = 'My Client ID';
+const clientSecret = 'My Client Secret';
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), { headers: { 'Content-Type': 'application/json' } });
+
+describe('conversation.update', () => {
+  test('issues a PATCH to /v1/conversation/:conversationId with the update body', async () => {
+    const updateResponse = {
+      conversationId: 'abc123',
+      csatScore: 5,
+      csatCollectedAt: '2024-01-15T10:35:00.000Z',
+      csatCollectionMethod: 'api',
+      csatDidThatHelp: null,
+      title: null,
+      updatedAt: '2024-01-15T10:35:00.000Z',
+    };
+    const fetchMock = jest.fn(async (_url: string | URL | Request, _init?: RequestInit) =>
+      jsonResponse(updateResponse),
+    );
+    const client = new Lorikeet({
+      clientID,
+      clientSecret,
+      baseURL: 'https://api.example.com',
+      fetch: fetchMock,
+    });
+
+    const response = await client.conversation.update('abc123', { csatScore: 5 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://api.example.com/v1/conversation/abc123');
+    expect(init?.method?.toUpperCase()).toBe('PATCH');
+    expect(JSON.parse(String(init?.body))).toEqual({ csatScore: 5 });
+    expect(response).toEqual(updateResponse);
+  });
+
+  test('passes through all updatable fields', async () => {
+    const fetchMock = jest.fn(async (_url: string | URL | Request, _init?: RequestInit) =>
+      jsonResponse({
+        conversationId: 'abc123',
+        csatScore: 4,
+        csatCollectedAt: '2024-01-15T10:35:00.000Z',
+        csatCollectionMethod: 'api',
+        csatDidThatHelp: true,
+        title: 'Billing question',
+        updatedAt: '2024-01-15T10:35:00.000Z',
+      }),
+    );
+    const client = new Lorikeet({
+      clientID,
+      clientSecret,
+      baseURL: 'https://api.example.com',
+      fetch: fetchMock,
+    });
+
+    await client.conversation.update('abc123', {
+      csatScore: 4,
+      csatCollectedAt: '2024-01-15T10:35:00.000Z',
+      csatDidThatHelp: true,
+      title: 'Billing question',
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse(String(init?.body))).toEqual({
+      csatScore: 4,
+      csatCollectedAt: '2024-01-15T10:35:00.000Z',
+      csatDidThatHelp: true,
+      title: 'Billing question',
+    });
+  });
+});


### PR DESCRIPTION
Adds `client.conversation.update(conversationId, { csatScore, csatCollectedAt, csatDidThatHelp, title })` wrapping the new `PATCH /v1/conversation/{conversationId}` endpoint (optechai/support#24050), so headless integrations can submit a CSAT score collected in their own UI into Lorikeet. Requires server-to-server API credentials.

Linear: FEAT-234.

Hand-written pending the next Stainless regeneration (same as the `streamUpdates` auth fix in #214): once the server PR deploys and the OpenAPI spec is refreshed in Stainless, codegen should produce the equivalent method — the param/response types here match the server DTOs so the diff should be a no-op.

Tested with jest unit tests (`tests/lib/conversation-update.test.ts`) using an injected fetch mock: verifies PATCH verb, URL, JSON body passthrough, and parsed response. `./scripts/build` and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)