### PR TITLE
fix(types): enforce conversation CSAT timestamp dependency

### DIFF
--- a/api.md
+++ b/api.md
@@ -5,6 +5,11 @@ Types:
 - <code><a href="./src/resources/conversation/conversation.ts">AttachmentDto</a></code>
 - <code><a href="./src/resources/conversation/conversation.ts">TicketEvent</a></code>
 - <code><a href="./src/resources/conversation/conversation.ts">TicketMessageDto</a></code>
+- <code><a href="./src/resources/conversation/conversation.ts">ConversationUpdateResponse</a></code>
+
+Methods:
+
+- <code title="patch /v1/conversation/{conversationId}">client.conversation.<a href="./src/resources/conversation/conversation.ts">update</a>(conversationID, { ...params }) -> ConversationUpdateResponse</code>
 
 ## Email
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,6 +29,8 @@ import { Ingest, IngestSubmitParams, IngestTestParams } from './resources/ingest
 import {
   AttachmentDto,
   Conversation,
+  ConversationUpdateParams,
+  ConversationUpdateResponse,
   TicketEvent,
   TicketMessageDto,
 } from './resources/conversation/conversation';
@@ -820,6 +822,8 @@ export declare namespace Lorikeet {
     type AttachmentDto as AttachmentDto,
     type TicketEvent as TicketEvent,
     type TicketMessageDto as TicketMessageDto,
+    type ConversationUpdateResponse as ConversationUpdateResponse,
+    type ConversationUpdateParams as ConversationUpdateParams,
   };
 
   export {

--- a/src/resources/conversation/conversation.ts
+++ b/src/resources/conversation/conversation.ts
@@ -23,11 +23,34 @@ import {
 } from './email';
 import * as VoiceAPI from './voice';
 import { Voice, VoiceOutboundParams, VoiceOutboundResponse } from './voice';
+import { APIPromise } from '../../core/api-promise';
+import { RequestOptions } from '../../internal/request-options';
+import { path } from '../../internal/utils/path';
 
 export class Conversation extends APIResource {
   email: EmailAPI.Email = new EmailAPI.Email(this._client);
   chat: ChatAPI.Chat = new ChatAPI.Chat(this._client);
   voice: VoiceAPI.Voice = new VoiceAPI.Voice(this._client);
+
+  /**
+   * Update fields on a conversation, such as a CSAT score collected in your own UI.
+   * Requires server-to-server API credentials.
+   *
+   * @example
+   * ```ts
+   * const conversation = await client.conversation.update(
+   *   '182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e',
+   *   { csatScore: 1 },
+   * );
+   * ```
+   */
+  update(
+    conversationID: string,
+    body: ConversationUpdateParams,
+    options?: RequestOptions,
+  ): APIPromise<ConversationUpdateResponse> {
+    return this._client.patch(path`/v1/conversation/${conversationID}`, { body, ...options });
+  }
 }
 
 export interface AttachmentDto {
@@ -109,6 +132,85 @@ export interface TicketMessageDto {
   type: 'CUSTOMER' | 'BOT_RESPONSE' | 'PENDING_RESPONSE' | 'DRAFT_RESPONSE' | 'INTERNAL_MODEL_NOTE';
 }
 
+export interface ConversationUpdateResponse {
+  /**
+   * The ID of the conversation
+   */
+  conversationId: string;
+
+  /**
+   * When the CSAT response was collected (ISO 8601 format)
+   */
+  csatCollectedAt: string | null;
+
+  /**
+   * How the CSAT was collected
+   */
+  csatCollectionMethod: 'workflow' | 'widget_inactivity' | 'widget_close' | 'api' | null;
+
+  /**
+   * The customer's answer to a "did that help?" style prompt
+   */
+  csatDidThatHelp: boolean | null;
+
+  /**
+   * Customer satisfaction score for the conversation
+   */
+  csatScore: number | null;
+
+  /**
+   * The title of the conversation
+   */
+  title: string | null;
+
+  /**
+   * The timestamp of when the conversation was last updated in our system.
+   */
+  updatedAt: string;
+}
+
+export type ConversationUpdateParams =
+  | ConversationUpdateParams.ScoreUpdate
+  | ConversationUpdateParams.DidThatHelpUpdate
+  | ConversationUpdateParams.TitleUpdate;
+
+export declare namespace ConversationUpdateParams {
+  interface ScoreUpdate {
+    csatScore: 1 | 2 | 3 | 4 | 5;
+
+    /**
+     * When the CSAT response was collected (ISO 8601 format). Defaults to the time of
+     * the request. Only honoured together with csatScore.
+     */
+    csatCollectedAt?: string;
+
+    /**
+     * The customer's answer to a "did that help?" style prompt.
+     */
+    csatDidThatHelp?: boolean;
+
+    /**
+     * The title of the conversation.
+     */
+    title?: string;
+  }
+
+  // Explicit exclusions keep TypeScript's structural union aligned with the API dependency.
+  interface DidThatHelpUpdate {
+    csatDidThatHelp: boolean;
+    csatCollectedAt?: never;
+    csatScore?: never;
+    title?: string;
+  }
+
+  interface TitleUpdate {
+    title: string;
+    csatCollectedAt?: never;
+    csatDidThatHelp?: boolean;
+    csatScore?: never;
+  }
+}
+
 Conversation.Email = Email;
 Conversation.Chat = Chat;
 Conversation.Voice = Voice;
@@ -118,6 +220,8 @@ export declare namespace Conversation {
     type AttachmentDto as AttachmentDto,
     type TicketEvent as TicketEvent,
     type TicketMessageDto as TicketMessageDto,
+    type ConversationUpdateResponse as ConversationUpdateResponse,
+    type ConversationUpdateParams as ConversationUpdateParams,
   };
 
   export {

--- a/src/resources/conversation/index.ts
+++ b/src/resources/conversation/index.ts
@@ -14,7 +14,14 @@ export {
   type ChatStreamMessageChunkEvent,
   type ChatStreamMessageCompleteEvent,
 } from './chat';
-export { Conversation, type AttachmentDto, type TicketEvent, type TicketMessageDto } from './conversation';
+export {
+  Conversation,
+  type AttachmentDto,
+  type TicketEvent,
+  type TicketMessageDto,
+  type ConversationUpdateResponse,
+  type ConversationUpdateParams,
+} from './conversation';
 export {
   Email,
   type EmailGenerateResponse,

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -12,6 +12,8 @@ export {
   type AttachmentDto,
   type TicketEvent,
   type TicketMessageDto,
+  type ConversationUpdateResponse,
+  type ConversationUpdateParams,
 } from './conversation/conversation';
 export {
   Customer,

--- a/tests/lib/conversation-update.test.ts
+++ b/tests/lib/conversation-update.test.ts
@@ -1,4 +1,5 @@
 import Lorikeet from '@lorikeetai/node-sdk';
+import type { ConversationUpdateParams, ConversationUpdateResponse } from '@lorikeetai/node-sdk/resources';
 
 const clientID = 'My Client ID';
 const clientSecret = 'My Client Secret';
@@ -27,7 +28,7 @@ describe('conversation.update', () => {
       fetch: fetchMock,
     });
 
-    const response = await client.conversation.update('abc123', {
+    const response: ConversationUpdateResponse = await client.conversation.update('abc123', {
       csatScore: 5,
       csatCollectedAt: '2024-01-15T10:35:00.000Z',
       csatDidThatHelp: true,
@@ -48,7 +49,7 @@ describe('conversation.update', () => {
   });
 
   test('requires csatScore when csatCollectedAt is present', () => {
-    const acceptsParams = (params: Lorikeet.Conversation.ConversationUpdateParams) => params;
+    const acceptsParams = (params: ConversationUpdateParams) => params;
 
     expect(acceptsParams({ csatScore: 1 })).toEqual({ csatScore: 1 });
     expect(acceptsParams({ csatScore: 5, csatCollectedAt: '2024-01-15T10:35:00.000Z' })).toEqual({

--- a/tests/lib/conversation-update.test.ts
+++ b/tests/lib/conversation-update.test.ts
@@ -1,0 +1,78 @@
+import Lorikeet from '@lorikeetai/node-sdk';
+
+const clientID = 'My Client ID';
+const clientSecret = 'My Client Secret';
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), { headers: { 'Content-Type': 'application/json' } });
+
+describe('conversation.update', () => {
+  test('issues a PATCH with the update body', async () => {
+    const updateResponse = {
+      conversationId: 'abc123',
+      csatCollectedAt: '2024-01-15T10:35:00.000Z',
+      csatCollectionMethod: 'api' as const,
+      csatDidThatHelp: true,
+      csatScore: 5,
+      title: 'Billing question',
+      updatedAt: '2024-01-15T10:35:00.000Z',
+    };
+    const fetchMock = jest.fn(async (_url: string | URL | Request, _init?: RequestInit) =>
+      jsonResponse(updateResponse),
+    );
+    const client = new Lorikeet({
+      clientID,
+      clientSecret,
+      baseURL: 'https://api.example.com',
+      fetch: fetchMock,
+    });
+
+    const response = await client.conversation.update('abc123', {
+      csatScore: 5,
+      csatCollectedAt: '2024-01-15T10:35:00.000Z',
+      csatDidThatHelp: true,
+      title: 'Billing question',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://api.example.com/v1/conversation/abc123');
+    expect(init?.method).toBe('PATCH');
+    expect(JSON.parse(String(init?.body))).toEqual({
+      csatScore: 5,
+      csatCollectedAt: '2024-01-15T10:35:00.000Z',
+      csatDidThatHelp: true,
+      title: 'Billing question',
+    });
+    expect(response).toEqual(updateResponse);
+  });
+
+  test('requires csatScore when csatCollectedAt is present', () => {
+    const acceptsParams = (params: Lorikeet.Conversation.ConversationUpdateParams) => params;
+
+    expect(acceptsParams({ csatScore: 1 })).toEqual({ csatScore: 1 });
+    expect(acceptsParams({ csatScore: 5, csatCollectedAt: '2024-01-15T10:35:00.000Z' })).toEqual({
+      csatScore: 5,
+      csatCollectedAt: '2024-01-15T10:35:00.000Z',
+    });
+    expect(acceptsParams({ csatDidThatHelp: false })).toEqual({ csatDidThatHelp: false });
+    expect(acceptsParams({ title: 'Billing question' })).toEqual({ title: 'Billing question' });
+    expect(acceptsParams({ csatDidThatHelp: true, title: 'Billing question' })).toEqual({
+      csatDidThatHelp: true,
+      title: 'Billing question',
+    });
+
+    if (false) {
+      // @ts-expect-error At least one mutable field is required.
+      acceptsParams({});
+      // @ts-expect-error csatScore must be an integer from 1 through 5.
+      acceptsParams({ csatScore: 0 });
+      // @ts-expect-error csatCollectedAt requires csatScore.
+      acceptsParams({ csatCollectedAt: '2024-01-15T10:35:00.000Z' });
+      // @ts-expect-error csatCollectedAt requires csatScore.
+      acceptsParams({ title: 'Billing question', csatCollectedAt: '2024-01-15T10:35:00.000Z' });
+      // @ts-expect-error csatCollectedAt requires csatScore.
+      acceptsParams({ csatDidThatHelp: true, csatCollectedAt: '2024-01-15T10:35:00.000Z' });
+    }
+  });
+});


### PR DESCRIPTION
## What changed and why

Adds `client.conversation.update()` for `PATCH /v1/conversation/{conversationId}` as Stainless custom code and aligns its TypeScript request type with the server contract from optechai/support#24050 and optechai/support#24448.

Stainless generated the non-score alternatives as structural object types. That allowed `{ title, csatCollectedAt }` and `{ csatDidThatHelp, csatCollectedAt }` to type-check even though the API requires `csatScore` whenever `csatCollectedAt` is present. The non-score alternatives now explicitly exclude both CSAT score fields with `never`.

FEAT-234.

## How this was tested

Exercised the method through an injected fetch implementation and verified the PATCH path, serialized body, and parsed response. Compiled score-only, help-only, title-only, and combined updates, plus negative cases for empty updates, invalid scores, and collection timestamps without a score. Built and imported the package through both CommonJS and ESM entry points.

## Monitoring

Before publishing, install the package produced by the updated release PR and repeat the consumer compile test. Runtime validation remains enforced by the API.