### PR TITLE
[GOA-25] feat(customer-events): add ingestion method

### DIFF
--- a/api.md
+++ b/api.md
@@ -95,6 +95,18 @@ Methods:
 - <code title="post /ingest/test/{toolId}">client.ingest.<a href="./src/resources/ingest.ts">test</a>(toolID, { ...params }) -> void</code>
 - <code title="post /ingest/validate">client.ingest.<a href="./src/resources/ingest.ts">validate</a>() -> void</code>
 
+# CustomerEvents
+
+Types:
+
+- <code><a href="./src/resources/customer-events.ts">CustomerEventIngestResponse</a></code>
+- <code><a href="./src/resources/customer-events.ts">CustomerEventCustomer</a></code>
+- <code><a href="./src/resources/customer-events.ts">CustomerEventPaymentFailedData</a></code>
+
+Methods:
+
+- <code title="post /v1/customer-events">client.customerEvents.<a href="./src/resources/customer-events.ts">ingest</a>({ ...params }) -> CustomerEventIngestResponse</code>
+
 # APIKeys
 
 Types:

--- a/src/client.ts
+++ b/src/client.ts
@@ -27,6 +27,13 @@ import {
 } from './resources/api-keys';
 import { Ingest, IngestSubmitParams, IngestTestParams } from './resources/ingest';
 import {
+  CustomerEvents,
+  CustomerEventIngestResponse,
+  CustomerEventCustomer,
+  CustomerEventPaymentFailedData,
+  CustomerEventIngestParams,
+} from './resources/customer-events';
+import {
   AttachmentDto,
   Conversation,
   ConversationUpdateParams,
@@ -809,12 +816,17 @@ export class Lorikeet {
    * Endpoints for ingesting subscriber data
    */
   ingest: API.Ingest = new API.Ingest(this);
+  /**
+   * Endpoints for ingesting Customer Events
+   */
+  customerEvents: API.CustomerEvents = new API.CustomerEvents(this);
   apiKeys: API.APIKeys = new API.APIKeys(this);
 }
 
 Lorikeet.Conversation = Conversation;
 Lorikeet.Customer = Customer;
 Lorikeet.Ingest = Ingest;
+Lorikeet.CustomerEvents = CustomerEvents;
 Lorikeet.APIKeys = APIKeys;
 
 export declare namespace Lorikeet {
@@ -845,6 +857,14 @@ export declare namespace Lorikeet {
     Ingest as Ingest,
     type IngestSubmitParams as IngestSubmitParams,
     type IngestTestParams as IngestTestParams,
+  };
+
+  export {
+    CustomerEvents as CustomerEvents,
+    type CustomerEventIngestResponse as CustomerEventIngestResponse,
+    type CustomerEventCustomer as CustomerEventCustomer,
+    type CustomerEventPaymentFailedData as CustomerEventPaymentFailedData,
+    type CustomerEventIngestParams as CustomerEventIngestParams,
   };
 
   export {

--- a/src/resources/customer-events.ts
+++ b/src/resources/customer-events.ts
@@ -1,0 +1,115 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import { APIResource } from '../core/resource';
+import { APIPromise } from '../core/api-promise';
+import { RequestOptions } from '../internal/request-options';
+
+/**
+ * Endpoints for ingesting Customer Events
+ */
+export class CustomerEvents extends APIResource {
+  /**
+   * Ingest a Customer Event. Reusing a source Event ID returns the Event already stored.
+   *
+   * @example
+   * ```ts
+   * const event = await client.customerEvents.ingest({
+   *   sourceEventId: '182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e',
+   *   eventType: 'payment_failed',
+   *   customer: { subscriberCustomerId: 'customer-123' },
+   *   data: {
+   *     amountMinorUnits: 2500,
+   *     currency: 'AUD',
+   *     failureCode: 'insufficient_funds',
+   *   },
+   * });
+   * ```
+   */
+  ingest(body: CustomerEventIngestParams, options?: RequestOptions): APIPromise<CustomerEventIngestResponse> {
+    return this._client.post('/v1/customer-events', { body, ...options });
+  }
+}
+
+export interface CustomerEventIngestResponse {
+  /**
+   * The Lorikeet ID of the stored Customer Event.
+   */
+  id: string;
+
+  /**
+   * The source Event ID supplied in the request.
+   */
+  sourceEventId: string;
+
+  /**
+   * Whether this request created the Customer Event.
+   */
+  created: boolean;
+}
+
+export interface CustomerEventCustomer {
+  /**
+   * The Lorikeet Customer ID.
+   */
+  customerId?: string;
+
+  /**
+   * The Customer ID in the Subscriber's ticketing system.
+   */
+  remoteId?: string;
+
+  /**
+   * The Customer ID in the Subscriber's primary system.
+   */
+  subscriberCustomerId?: string;
+
+  email?: string;
+
+  phoneNumber?: string;
+}
+
+export interface CustomerEventPaymentFailedData {
+  [key: string]: unknown;
+
+  /**
+   * The failed payment amount in the currency's minor unit.
+   */
+  amountMinorUnits: number;
+
+  /**
+   * The three-letter ISO 4217 currency code.
+   */
+  currency: string;
+
+  /**
+   * The source system's failure code.
+   */
+  failureCode: string;
+}
+
+export interface CustomerEventIngestParams {
+  /**
+   * A stable UUID supplied by the Event producer.
+   */
+  sourceEventId: string;
+
+  eventType: 'payment_failed';
+
+  customer: CustomerEventCustomer;
+
+  data: CustomerEventPaymentFailedData;
+
+  /**
+   * When the Event occurred in the source system. Defaults to receipt time.
+   */
+  occurredAt?: string;
+}
+
+export declare namespace CustomerEvents {
+  export {
+    type CustomerEventIngestResponse as CustomerEventIngestResponse,
+    type CustomerEventCustomer as CustomerEventCustomer,
+    type CustomerEventPaymentFailedData as CustomerEventPaymentFailedData,
+    type CustomerEventIngestParams as CustomerEventIngestParams,
+  };
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -27,3 +27,10 @@ export {
   type CustomerTokenParams,
 } from './customer/customer';
 export { Ingest, type IngestSubmitParams, type IngestTestParams } from './ingest';
+export {
+  CustomerEvents,
+  type CustomerEventIngestResponse,
+  type CustomerEventCustomer,
+  type CustomerEventPaymentFailedData,
+  type CustomerEventIngestParams,
+} from './customer-events';

--- a/tests/api-resources/customer-events.test.ts
+++ b/tests/api-resources/customer-events.test.ts
@@ -1,0 +1,50 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import Lorikeet from '@lorikeetai/node-sdk';
+import { generateSignature } from '@lorikeetai/node-sdk/lib/generate-signature';
+
+const clientID = 'My Client ID';
+const clientSecret = 'My Client Secret';
+
+describe('resource customerEvents', () => {
+  test('ingest: sends the typed Event with client authentication', async () => {
+    const sourceEventId = '182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e';
+    const body = {
+      sourceEventId,
+      eventType: 'payment_failed' as const,
+      occurredAt: '2026-08-13T03:00:00.000Z',
+      customer: { subscriberCustomerId: 'customer-123' },
+      data: {
+        amountMinorUnits: 2500,
+        currency: 'AUD',
+        failureCode: 'insufficient_funds',
+      },
+    };
+    const fetchMock = jest.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
+      return new Response(JSON.stringify({ id: 'event-123', sourceEventId, created: true }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    const client = new Lorikeet({
+      clientID,
+      clientSecret,
+      baseURL: 'https://api.example.com',
+      fetch: fetchMock,
+    });
+
+    await expect(client.customerEvents.ingest(body)).resolves.toEqual({
+      id: 'event-123',
+      sourceEventId,
+      created: true,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [input, init] = fetchMock.mock.calls[0]!;
+    expect(input.toString()).toBe('https://api.example.com/v1/customer-events');
+    expect(init?.method).toBe('POST');
+    expect(init?.body).toBe(JSON.stringify(body));
+
+    const headers = new Headers(init?.headers);
+    expect(headers.get('authorization')).toBe(`Bearer ${clientID}`);
+    expect(headers.get('x-lorikeet-signature')).toBe(generateSignature(JSON.stringify(body), clientSecret));
+  });
+});


### PR DESCRIPTION
## Summary

- Add typed customerEvents.ingest support for POST /v1/customer-events.
- Reuse the existing SDK bearer authentication and HMAC signing.
- Document the payment_failed request and ingestion response.

## Testing

- SDK lint, build, type checks, package checks, and focused test pass.
- The focused test verifies the exact URL, serialized body, bearer header, and HMAC signature.
- The built SDK was exercised against the local dev server and persisted one mocked payment_failed Event.

Linear: GOA-25