### PR TITLE
[GOA-82] feat(customer): add consent update method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ const response = await client.conversation.chat.start({
 console.log(response.conversationId);
 ```
 
+### Update customer consent
+
+The client signs the request with its configured client ID and secret.
+
+```ts
+const consent = await client.customer.updateConsent({
+  customerId: '182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e',
+  channelType: 'VOICE',
+  consentStatus: 'OPTED_OUT',
+  source: 'crm_sync',
+  effectiveAt: '2026-08-17T10:00:00.000Z',
+});
+
+console.log(consent.consentStatus);
+```
+
 ### Request & Response types
 
 This library includes TypeScript definitions for all request params and response fields. You may import and use them like so:

--- a/api.md
+++ b/api.md
@@ -55,6 +55,7 @@ Types:
 
 - <code><a href="./src/resources/customer/customer.ts">CustomerCreateResponse</a></code>
 - <code><a href="./src/resources/customer/customer.ts">CustomerUpdateResponse</a></code>
+- <code><a href="./src/resources/customer/customer.ts">CustomerUpdateConsentResponse</a></code>
 - <code><a href="./src/resources/customer/customer.ts">CustomerGetResponse</a></code>
 - <code><a href="./src/resources/customer/customer.ts">CustomerTokenResponse</a></code>
 
@@ -62,6 +63,7 @@ Methods:
 
 - <code title="post /v1/customer">client.customer.<a href="./src/resources/customer/customer.ts">create</a>({ ...params }) -> CustomerCreateResponse</code>
 - <code title="put /v1/customer/{id}">client.customer.<a href="./src/resources/customer/customer.ts">update</a>(id, { ...params }) -> CustomerUpdateResponse</code>
+- <code title="put /v1/customer/consent">client.customer.<a href="./src/resources/customer/customer.ts">updateConsent</a>({ ...params }) -> CustomerUpdateConsentResponse</code>
 - <code title="get /v1/customer">client.customer.<a href="./src/resources/customer/customer.ts">get</a>({ ...params }) -> CustomerGetResponse</code>
 - <code title="post /v1/customer/token">client.customer.<a href="./src/resources/customer/customer.ts">token</a>({ ...params }) -> string</code>
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -51,6 +51,8 @@ import {
   CustomerTokenResponse,
   CustomerUpdateParams,
   CustomerUpdateResponse,
+  CustomerUpdateConsentParams,
+  CustomerUpdateConsentResponse,
 } from './resources/customer/customer';
 import { type Fetch } from './internal/builtin-types';
 import { HeadersLike, NullableHeaders, buildHeaders } from './internal/headers';
@@ -845,10 +847,12 @@ export declare namespace Lorikeet {
     Customer as Customer,
     type CustomerCreateResponse as CustomerCreateResponse,
     type CustomerUpdateResponse as CustomerUpdateResponse,
+    type CustomerUpdateConsentResponse as CustomerUpdateConsentResponse,
     type CustomerGetResponse as CustomerGetResponse,
     type CustomerTokenResponse as CustomerTokenResponse,
     type CustomerCreateParams as CustomerCreateParams,
     type CustomerUpdateParams as CustomerUpdateParams,
+    type CustomerUpdateConsentParams as CustomerUpdateConsentParams,
     type CustomerGetParams as CustomerGetParams,
     type CustomerTokenParams as CustomerTokenParams,
   };

--- a/src/resources/customer/customer.ts
+++ b/src/resources/customer/customer.ts
@@ -253,7 +253,7 @@ export interface CustomerUpdateConsentResponse {
    * When this consent record expires. An unexpired OPTED_OUT record suppresses
    * outbound contact.
    */
-  expiresAt: string | null;
+  expiresAt?: string | null;
 
   createdAt: string;
 

--- a/src/resources/customer/customer.ts
+++ b/src/resources/customer/customer.ts
@@ -45,6 +45,25 @@ export class Customer extends APIResource {
   /**
    * @example
    * ```ts
+   * const consent = await client.customer.updateConsent({
+   *   customerId: '182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e',
+   *   channelType: 'VOICE',
+   *   consentStatus: 'OPTED_OUT',
+   *   source: 'crm_sync',
+   *   effectiveAt: '2026-08-17T10:00:00.000Z',
+   * });
+   * ```
+   */
+  updateConsent(
+    body: CustomerUpdateConsentParams,
+    options?: RequestOptions,
+  ): APIPromise<CustomerUpdateConsentResponse> {
+    return this._client.put('/v1/customer/consent', { body, ...options });
+  }
+
+  /**
+   * @example
+   * ```ts
    * const customer = await client.customer.get();
    * ```
    */
@@ -196,6 +215,49 @@ export interface CustomerUpdateResponse {
    * JWT
    */
   subscriberToken?: string;
+}
+
+export interface CustomerUpdateConsentResponse {
+  /**
+   * The consent record ID.
+   */
+  id: string;
+
+  /**
+   * The Lorikeet Customer ID.
+   */
+  customerId: string;
+
+  /**
+   * The outbound channel whose consent state was updated.
+   */
+  channelType: 'VOICE' | 'SMS' | 'WHATSAPP' | 'EMAIL';
+
+  /**
+   * The resulting consent state.
+   */
+  consentStatus: 'OPTED_IN' | 'OPTED_OUT' | 'UNKNOWN';
+
+  /**
+   * The external system or process that supplied the decision.
+   */
+  source: string;
+
+  /**
+   * When the consent decision took effect. This is an audit timestamp; the update
+   * is applied immediately.
+   */
+  effectiveAt: string;
+
+  /**
+   * When this consent record expires. An unexpired OPTED_OUT record suppresses
+   * outbound contact.
+   */
+  expiresAt: string | null;
+
+  createdAt: string;
+
+  updatedAt: string;
 }
 
 export interface CustomerGetResponse {
@@ -366,6 +428,40 @@ export interface CustomerUpdateParams {
   subscriberToken?: string;
 }
 
+export interface CustomerUpdateConsentParams {
+  /**
+   * The Lorikeet Customer ID.
+   */
+  customerId: string;
+
+  /**
+   * The outbound channel whose consent state is being updated.
+   */
+  channelType: 'VOICE' | 'SMS' | 'WHATSAPP' | 'EMAIL';
+
+  /**
+   * The resulting consent state.
+   */
+  consentStatus: 'OPTED_IN' | 'OPTED_OUT' | 'UNKNOWN';
+
+  /**
+   * The external system or process that supplied the decision.
+   */
+  source: string;
+
+  /**
+   * When the consent decision took effect. This is an audit timestamp; the update
+   * is applied immediately.
+   */
+  effectiveAt: string;
+
+  /**
+   * When this consent record expires. An unexpired OPTED_OUT record suppresses
+   * outbound contact.
+   */
+  expiresAt?: string | null;
+}
+
 export interface CustomerGetParams {
   /**
    * The email address of the customer
@@ -457,10 +553,12 @@ export declare namespace Customer {
   export {
     type CustomerCreateResponse as CustomerCreateResponse,
     type CustomerUpdateResponse as CustomerUpdateResponse,
+    type CustomerUpdateConsentResponse as CustomerUpdateConsentResponse,
     type CustomerGetResponse as CustomerGetResponse,
     type CustomerTokenResponse as CustomerTokenResponse,
     type CustomerCreateParams as CustomerCreateParams,
     type CustomerUpdateParams as CustomerUpdateParams,
+    type CustomerUpdateConsentParams as CustomerUpdateConsentParams,
     type CustomerGetParams as CustomerGetParams,
     type CustomerTokenParams as CustomerTokenParams,
   };

--- a/src/resources/customer/index.ts
+++ b/src/resources/customer/index.ts
@@ -4,10 +4,12 @@ export {
   Customer,
   type CustomerCreateResponse,
   type CustomerUpdateResponse,
+  type CustomerUpdateConsentResponse,
   type CustomerGetResponse,
   type CustomerTokenResponse,
   type CustomerCreateParams,
   type CustomerUpdateParams,
+  type CustomerUpdateConsentParams,
   type CustomerGetParams,
   type CustomerTokenParams,
 } from './customer';

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -19,10 +19,12 @@ export {
   Customer,
   type CustomerCreateResponse,
   type CustomerUpdateResponse,
+  type CustomerUpdateConsentResponse,
   type CustomerGetResponse,
   type CustomerTokenResponse,
   type CustomerCreateParams,
   type CustomerUpdateParams,
+  type CustomerUpdateConsentParams,
   type CustomerGetParams,
   type CustomerTokenParams,
 } from './customer/customer';

--- a/tests/api-resources/customer/customer.test.ts
+++ b/tests/api-resources/customer/customer.test.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import Lorikeet from '@lorikeetai/node-sdk';
+import { generateSignature } from '@lorikeetai/node-sdk/lib/generate-signature';
 
 const client = new Lorikeet({
   clientID: 'My Client ID',
@@ -29,6 +30,49 @@ describe('resource customer', () => {
     const dataAndResponse = await responsePromise.withResponse();
     expect(dataAndResponse.data).toBe(response);
     expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  test('updateConsent: sends the typed update with client authentication', async () => {
+    const body = {
+      customerId: '182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e',
+      channelType: 'VOICE' as const,
+      consentStatus: 'OPTED_OUT' as const,
+      source: 'crm_sync',
+      effectiveAt: '2026-08-17T10:00:00.000Z',
+    };
+    const fetchMock = jest.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
+      return new Response(
+        JSON.stringify({
+          id: '282bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e',
+          ...body,
+          expiresAt: null,
+          createdAt: '2026-08-17T10:00:01.000Z',
+          updatedAt: '2026-08-17T10:00:01.000Z',
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      );
+    });
+    const authenticatedClient = new Lorikeet({
+      clientID: 'My Client ID',
+      clientSecret: 'My Client Secret',
+      baseURL: 'https://api.example.com',
+      fetch: fetchMock,
+    });
+
+    await expect(authenticatedClient.customer.updateConsent(body)).resolves.toMatchObject({
+      customerId: body.customerId,
+      consentStatus: 'OPTED_OUT',
+    });
+    const [input, init] = fetchMock.mock.calls[0]!;
+    expect(input.toString()).toBe('https://api.example.com/v1/customer/consent');
+    expect(init?.method).toBe('PUT');
+    expect(init?.body).toBe(JSON.stringify(body));
+
+    const headers = new Headers(init?.headers);
+    expect(headers.get('authorization')).toBe('Bearer My Client ID');
+    expect(headers.get('x-lorikeet-signature')).toBe(
+      generateSignature(JSON.stringify(body), 'My Client Secret'),
+    );
   });
 
   test('get', async () => {


### PR DESCRIPTION
## Summary

- add the typed `client.customer.updateConsent()` method for GOA-82
- use the SDK client's existing signed request path
- export request and response types
- document an opt-out example in the README and API index

## Testing

- `corepack yarn test tests/api-resources/customer/customer.test.ts --runInBand`
- `corepack yarn lint`

The focused test checks the request URL, method, serialized body, bearer client ID, and HMAC signature.

## Release note

The method becomes public when the next `@lorikeetai/node-sdk` version is published.
